### PR TITLE
add tests

### DIFF
--- a/addon/services/cordova.js
+++ b/addon/services/cordova.js
@@ -1,0 +1,92 @@
+import Ember from 'ember';
+
+const {
+  A,
+  Service,
+  Evented,
+  RSVP
+} = Ember;
+
+const { Promise } = RSVP;
+
+// from https://cordova.apache.org/docs/en/4.0.0/cordova_events_events.md.html
+const CORDOVA_EVENTS = new A([
+  'deviceready',
+  'pause',
+  'resume',
+  'backbutton',
+  'menubutton',
+  'searchbutton',
+  'startcallbutton',
+  'endcallbutton',
+  'volumedownbutton',
+  'volumeupbutton',
+  'batterycritical',
+  'batterylow',
+  'batterystatus',
+  'online',
+  'offline'
+]);
+
+export default Service.extend(Evented, {
+  _listeners: undefined,
+  _ready: undefined,
+  _readyHasTriggered: false,
+
+  init() {
+    this._super();
+
+    this._listeners = [];
+    this._ready = RSVP.defer();
+
+    this.setupReady();
+    this.setupListeners();
+  },
+
+  setupListeners() {
+    CORDOVA_EVENTS.forEach(name => {
+      const listener = {
+        name,
+        method: e => { this.trigger(name, e); }
+      };
+
+      this._listeners.push(listener);
+      document.addEventListener(listener.name, listener.method, true);
+    });
+  },
+
+  setupReady() {
+    this.on('deviceready', () => {
+      this._readyHasTriggered = true;
+      this._ready.resolve();
+      this._ready = null;
+    });
+  },
+
+  on(event, handler) {
+    if (event === 'deviceready' && this._readyHasTriggered) {
+      run.join(handler);
+    }
+    return this._super(event, handler);
+  },
+
+  ready() {
+    return this._readyHasTriggered ? Promise.resolve() : this._ready.promise;
+  },
+
+  willDestroy() {
+    this._super();
+    this.teardownListeners();
+
+    if (this._ready) {
+      this._ready.reject();
+      this._ready = null;
+    }
+  },
+
+  teardownListeners() {
+    this._listeners.forEach(listener => {
+      document.removeEventListener(listener.name, listener.method, true);
+    });
+  }
+});

--- a/addon/services/cordova/keyboard.js
+++ b/addon/services/cordova/keyboard.js
@@ -6,6 +6,7 @@ const {
   Evented,
   RSVP,
   Service,
+  copy,
   inject,
   run
 } = Ember;
@@ -122,7 +123,7 @@ export default Service.extend(Evented, {
   },
 
   teardownListeners() {
-    const listeners = this._listeners;
+    const listeners = copy(this._listeners); // cache for iterator manipulation
 
     listeners.forEach(listener => {
       window.removeEventListener(listener.name, listener.fn, true);

--- a/addon/services/cordova/keyboard.js
+++ b/addon/services/cordova/keyboard.js
@@ -78,6 +78,14 @@ export default Service.extend(Evented, {
   },
 
   disableScroll(bool) {
+    if (bool === undefined) {
+      bool = true;
+    }
+
+    if (bool !== true && bool !== false) {
+      throw new Error('invalid argument');
+    }
+
     this.keyboard().then((kb) => {
       this.set('shouldDisableScroll', bool);
       kb.disableScroll(bool);

--- a/addon/services/cordova/keyboard.js
+++ b/addon/services/cordova/keyboard.js
@@ -20,7 +20,7 @@ export default Service.extend(Evented, {
   shouldDisableScroll: true,
   keyboardHeight: 0,
 
-  _listeners: [],
+  _listeners: null,
   _height: null,
 
   init() {
@@ -90,11 +90,7 @@ export default Service.extend(Evented, {
           ];
 
     kb.disableScroll(this.get('shouldDisableScroll'));
-
-    listeners.forEach(listener => {
-      this._listeners.pushObject(listener);
-      window.addEventListener(listener.name, listener.fn, true);
-    });
+    this.setupListeners(listeners);
   },
 
   onKeyboardShow(e) {
@@ -116,6 +112,13 @@ export default Service.extend(Evented, {
     }
 
     this.trigger('keyboardDidHide', e);
+  },
+
+  setupListeners(listeners) {
+    listeners.forEach(listener => {
+      window.addEventListener(listener.name, listener.fn, true);
+      this._listeners.pushObject(listener);
+    });
   },
 
   teardownListeners() {

--- a/addon/services/cordova/keyboard.js
+++ b/addon/services/cordova/keyboard.js
@@ -1,4 +1,4 @@
-/* global cordova */
+/* global context */
 import Ember from 'ember';
 
 const {
@@ -42,7 +42,7 @@ export default Service.extend(Evented, {
 
     return this.get('cordova').ready()
       .then(() => {
-        this._keyboard = cordova.plugins.Keyboard;
+        this._keyboard = context.cordova.plugins.Keyboard;
         return this._keyboard;
       });
   },

--- a/addon/services/cordova/keyboard.js
+++ b/addon/services/cordova/keyboard.js
@@ -31,8 +31,8 @@ export default Service.extend(Evented, {
   },
 
   willDestroy() {
-    this._super();
     this.teardownListeners();
+    this._super();
   },
 
   _keyboard: null,

--- a/addon/services/cordova/keyboard.js
+++ b/addon/services/cordova/keyboard.js
@@ -54,7 +54,7 @@ export default Service.extend(Evented, {
 
       if (kb.isVisible) {
         if (elementShouldFocus) { element.focus(); }
-        return true;
+        return Promise.resolve();
       }
 
       return new Promise(resolve => {
@@ -66,7 +66,9 @@ export default Service.extend(Evented, {
 
   close() {
     return this.keyboard().then(kb => {
-      if (!kb.isVisible) { return true; }
+      if (!kb.isVisible) {
+        return Promise.resolve();
+      }
 
       return new Promise(resolve => {
         kb.close();

--- a/app/services/cordova.js
+++ b/app/services/cordova.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cordova-keyboard/services/cordova';

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "ember-cli-test-loader": "0.2.2",
     "mocha": "~2.2.4",
     "chai": "~2.3.0",
-    "ember-mocha-adapter": "~0.3.1"
+    "ember-mocha-adapter": "~0.3.1",
+    "testdouble": "testdouble/testdouble.js#^1.4.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,8 @@
     "ember": "~2.4.1",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0"
+    "mocha": "~2.2.4",
+    "chai": "~2.3.0",
+    "ember-mocha-adapter": "~0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ember-cli-mocha": "0.10.4",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
+    "ember-cli-testdouble": "0.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.4.0",
     "ember-disable-prototype-extensions": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.2.1",
+    "ember-cli-mocha": "0.10.4",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",

--- a/testem.js
+++ b/testem.js
@@ -1,6 +1,6 @@
 /*jshint node:true*/
 module.exports = {
-  "framework": "qunit",
+  "framework": "mocha",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,6 +1,4 @@
 import resolver from './helpers/resolver';
-import {
-  setResolver
-} from 'ember-qunit';
+import { setResolver } from 'ember-mocha';
 
 setResolver(resolver);

--- a/tests/unit/services/cordova/keyboard-test.js
+++ b/tests/unit/services/cordova/keyboard-test.js
@@ -1,12 +1,460 @@
-import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
 
-moduleFor('service:cordova/keyboard', 'Unit | Service | cordova/keyboard', {
-  // Specify the other units that are required for this test.
-  // needs: ['service:foo']
-});
+import td from 'testdouble';
+import { describeModule } from 'ember-mocha';
+import {
+  afterEach,
+  beforeEach,
+  context,
+  describe,
+  it
+} from 'mocha';
 
-// Replace this with your real tests.
-test('it exists', function(assert) {
-  let service = this.subject();
-  assert.ok(service);
-});
+const {
+  A,
+  RSVP: { Promise }
+} = Ember;
+
+describeModule(
+  'service:cordova/keyboard',
+  'KeyboardService',
+  {
+    needs: [
+      'service:cordova'
+    ]
+  },
+  function() {
+    let cordova, keyboardPlugin, service;
+
+    beforeEach(function() {
+      cordova = this.container.owner.lookup('service:cordova'); // todo getOwner polyfill?
+
+      context.cordova = {
+        plugins: {
+          Keyboard: {
+            disableScroll: function() {
+            }
+          }
+        }
+      };
+
+      service = this.subject();
+      keyboardPlugin = context.cordova.plugins.Keyboard;
+
+      cordova.trigger('deviceready');
+    });
+
+    afterEach(function() {
+      td.reset();
+    });
+
+    describe('#init', function() {
+      it('exists', function() {
+        expect(service).to.be.ok;
+      });
+    });
+
+    describe('#willDestroy', function() {
+      let teardownListenersCalled;
+
+      beforeEach(function() {
+        teardownListenersCalled = false;
+
+        td.replace(service, 'teardownListeners', function() {
+          teardownListenersCalled = true;
+        });
+
+        service.teardownListeners();
+      });
+
+      it('tears down listeners', function() {
+        expect(teardownListenersCalled).to.be.true;
+      });
+    });
+
+    describe('#keyboard', function() {
+      let keyboard;
+
+      beforeEach(function() {
+        service.keyboard()
+          .then((_keyboard) => {
+            keyboard = _keyboard;
+          });
+      });
+
+      it('returns the keyboard plugin object', function() {
+        expect(keyboard).to.equal(keyboardPlugin);
+      });
+
+      it('caches the keyboard plugin object on the service', function() {
+        expect(service._keyboard).to.equal(keyboardPlugin);
+      });
+    });
+
+    describe('#open', function() {
+      let element, focusCalled, promise;
+
+      beforeEach(function() {
+        focusCalled = false;
+      });
+
+      context('when element is not the active element', function() {
+        beforeEach(function() {
+          element = {
+            focus() {
+              focusCalled = true;
+            }
+          };
+
+          promise = service.open(element);
+        });
+
+        it('returns a promise', function() {
+          let isPromise = promise instanceof Promise;
+          expect(isPromise).to.be.true;
+        });
+
+        it('calls focus on the element', function() {
+          expect(focusCalled).to.be.true;
+        });
+      });
+
+      context('when element is the active element', function() {
+        beforeEach(function() {
+          element = document.activeElement;
+          td.replace(element, 'focus', function() {
+            focusCalled = true;
+          });
+
+          promise = service.open(element);
+        });
+
+        it('returns a promise', function() {
+          let isPromise = promise instanceof Promise;
+          expect(isPromise).to.be.true;
+        });
+
+        it('does not call focus on the element', function() {
+          expect(focusCalled).to.be.false;
+        });
+      });
+    });
+
+    describe('#close', function() {
+      let closeCalled, promise;
+
+      beforeEach(function() {
+        closeCalled = false;
+
+        td.replace(keyboardPlugin, 'close', function() {
+          closeCalled = true;
+        });
+      });
+
+      context('when keyboard is visible', function() {
+        beforeEach(function() {
+          keyboardPlugin.isVisible = true;
+
+          promise = service.close();
+          return promise;
+        });
+
+        it('returns a promise', function() {
+          let isPromise = promise instanceof Promise;
+          expect(isPromise).to.be.true;
+        });
+
+        it('calls the cordova plugin\'s `close()`', function() {
+          expect(closeCalled).to.be.true;
+        });
+      });
+
+      context('when keyboard is not visible', function() {
+        beforeEach(function() {
+          keyboardPlugin.isVisible = false;
+        });
+
+        it('returns a promise', function() {
+          let isPromise = promise instanceof Promise;
+          expect(isPromise).to.be.true;
+        });
+
+        it('does not call the cordova plugin\'s `close()`', function() {
+          expect(closeCalled).to.be.false;
+        });
+      });
+    });
+
+    describe('#disableScroll', function() {
+      let disableScroll;
+
+      beforeEach(function() {
+        disableScroll = undefined;
+
+        td.replace(keyboardPlugin, 'disableScroll', function(bool) {
+          disableScroll = bool;
+        });
+      });
+
+      context('when called with no args', function() {
+        beforeEach(function() {
+          service.disableScroll();
+        });
+
+        it('passes `disableScroll(true)` to cordova', function() {
+          expect(disableScroll).to.be.true;
+        });
+      });
+
+      context('when called with true', function() {
+        beforeEach(function() {
+          service.disableScroll(true);
+        });
+
+        it('passes `disableScroll(true)` to cordova', function() {
+          expect(disableScroll).to.be.true;
+        });
+      });
+
+      context('when called with false', function() {
+        beforeEach(function() {
+          service.disableScroll(false);
+        });
+
+        it('passes `disableScroll(true)` to cordova', function() {
+          expect(disableScroll).to.be.false;
+        });
+      });
+
+      context('when called with invalid args', function() {
+        let fnDisableScroll;
+
+        beforeEach(function() {
+          fnDisableScroll = function() {
+            service.disableScroll(123);
+          };
+        });
+
+        it('throws', function() {
+          expect(fnDisableScroll).to.throw(Error);
+        });
+
+        it('does not call cordova\'s `disableScroll()', function() {
+          expect(disableScroll).to.be.undefined;
+        });
+      });
+    });
+
+    describe('#setup', function() {
+      let disableScroll, listeners;
+
+      beforeEach(function() {
+        disableScroll = undefined;
+
+        td.replace(keyboardPlugin, 'disableScroll', function(bool) {
+          disableScroll = bool;
+        });
+
+        td.replace(service, 'setupListeners', function(_listeners) {
+          listeners = new A(_listeners);
+        });
+
+        service.setup(keyboardPlugin);
+      });
+
+      it('calls cordova\'s `disableScroll()`', function() {
+        let expectedArg = service.get('shouldDisableScroll');
+        expect(disableScroll).to.equal(expectedArg);
+      });
+
+      it('calls setupListeners for keyboard[show|hide] events', function() {
+        let onKeyboardShow = listeners.findBy('name', 'native.keyboardshow').fn,
+            onKeyboardHide = listeners.findBy('name', 'native.keyboardhide').fn;
+
+        expect(onKeyboardShow.name).to.equal('bound onKeyboardShow');
+        expect(onKeyboardHide.name).to.equal('bound onKeyboardHide');
+      });
+    });
+
+    describe('#onKeyboardShow', function() {
+      let bodyHeight, keyboardHeight, event, keyboardDidShow;
+
+      beforeEach(function() {
+        bodyHeight = document.body.style.height;
+        keyboardHeight = 100;
+        event = { keyboardHeight: 100 };
+        keyboardDidShow = false;
+
+        service.on('keyboardDidShow', function() {
+          keyboardDidShow = true;
+        });
+      });
+
+      afterEach(function() {
+        document.body.style.height = bodyHeight;
+      });
+
+      context('when `adjustBodyHeight` is true', function() {
+        beforeEach(function() {
+          service.set('adjustBodyHeight', true);
+          service.onKeyboardShow(event);
+        });
+
+        it('caches `keyboardHeight`', function() {
+          expect(service.get('keyboardHeight')).to.equal(keyboardHeight);
+        });
+
+        it('triggers `keyboardDidShow', function() {
+          expect(keyboardDidShow).to.be.true;
+        });
+
+        it('caches body height in `_height`', function() {
+          expect(service._height).to.equal(bodyHeight);
+        });
+
+        it('calculates a new body height', function() {
+          let expectedHeight = 'calc(100% - ' + keyboardHeight + 'px)';
+          expect(document.body.style.height).to.equal(expectedHeight);
+        });
+      });
+
+      context('when `adjustBodyHeight` is not true', function() {
+        beforeEach(function() {
+          service.set('adjustBodyHeight', false);
+          service.onKeyboardShow(event);
+        });
+
+        it('caches `keyboardHeight`', function() {
+          expect(service.get('keyboardHeight')).to.equal(keyboardHeight);
+        });
+
+        it('triggers `keyboardDidShow', function() {
+          expect(keyboardDidShow).to.be.true;
+        });
+
+        it('does not calculate a new body height', function() {
+          expect(document.body.style.height).to.equal(bodyHeight);
+        });
+      });
+    });
+
+    describe('#onKeyboardHide', function() {
+      let bodyHeight, event, keyboardDidHide;
+
+      beforeEach(function() {
+        bodyHeight = document.body.style.height;
+        event = {};
+        keyboardDidHide = false;
+
+        service._height = bodyHeight;
+        service.on('keyboardDidHide', function() {
+          keyboardDidHide = true;
+        });
+      });
+
+      afterEach(function() {
+        document.body.style.height = bodyHeight;
+      });
+
+      context('when `adjustBodyHeight` is true', function() {
+        beforeEach(function() {
+          service.set('adjustBodyHeight', true);
+          service.onKeyboardHide(event);
+        });
+
+        it('resets `keyboardHeight` to 0', function() {
+          expect(service.get('keyboardHeight')).to.equal(0);
+        });
+
+        it('triggers `keyboardDidHide`', function() {
+          expect(keyboardDidHide).to.be.true;
+        });
+
+        it('resets body height to `_height`', function() {
+          expect(document.body.style.height).to.equal(service._height);
+        });
+      });
+
+      context('when `adjustBodyHeight` is not true', function() {
+        beforeEach(function() {
+          service.set('adjustBodyHeight', false);
+          service.onKeyboardHide(event);
+        });
+
+        it('resets `keyboardHeight` to 0', function() {
+          expect(service.get('keyboardHeight')).to.equal(0);
+        });
+
+        it('triggers `keyboardDidHide`', function() {
+          expect(keyboardDidHide).to.be.true;
+        });
+
+        it('does not reset body height', function() {
+          expect(document.body.style.height).to.equal(bodyHeight);
+        });
+      });
+    });
+
+    describe('#setupListeners', function() {
+      let listeners, passedListeners;
+
+      beforeEach(function() {
+        listeners = new A([
+          { name: 'foo', fn: function foo() {} },
+          { name: 'bar', fn: function bar() {} },
+          { name: 'baz', fn: function baz() {} }
+        ]);
+        passedListeners = new A();
+
+        td.replace(window, 'addEventListener', function(name, fn) {
+          let listener = { name: name, fn: fn };
+          passedListeners.pushObject(listener);
+        });
+
+        service._listeners = new A(); // reset cache; some were set via `init`
+        service.setupListeners(listeners);
+      });
+
+      it('calls addEventListener for each listener', function() {
+        listeners.forEach((listener) => {
+          let _listener = passedListeners.findBy('name', listener.name);
+          expect(_listener).to.deep.equal(listener);
+        });
+      });
+
+      it('adds each listener to `_listeners`', function() {
+        listeners.forEach((listener) => {
+          let _listener = service._listeners.findBy('name', listener.name);
+          expect(_listener).to.deep.equal(listener);
+        });
+      });
+    });
+
+    describe('#teardownListeners', function() {
+      let listeners, removedListeners;
+
+      beforeEach(function() {
+        listeners = service._listeners;
+        removedListeners = new A();
+
+        td.replace(window, 'removeEventListener', function(name, fn) {
+          let listener = { name: name, fn: fn };
+          removedListeners.pushObject(listener);
+        });
+
+        service.teardownListeners();
+      });
+
+      it('calls removeEventListener for each listener', function() {
+        listeners.forEach((listener) => {
+          let _listener = removedListeners.findBy('name', listener.name);
+          expect(_listener).to.deep.equal(listener);
+        });
+      });
+
+      it('rms each listener from `_listeners`', function() {
+        expect(service._listeners.length).to.equal(0);
+      });
+    });
+  }
+);


### PR DESCRIPTION
Tests implemented for the Cordova keyboard service. Remaining todos:
- [ ] implement w/ember-cordova-utils
  - [ ] rebase out shimmed cordova service
- [ ] replace jshint tests with ember-cordova's eslint config
