### PR TITLE
Update keyboard plugin

### DIFF
--- a/addon/services/ember-cordova/keyboard.js
+++ b/addon/services/ember-cordova/keyboard.js
@@ -37,7 +37,10 @@ export default Service.extend(Evented, {
 
     return new Promise((resolve) => {
       document.addEventListener("deviceready", () => {
-        this._keyboard = window.cordova.plugins.Keyboard;
+        // The location of Keyboard moved between ionic-plugin-keyboard and
+        // cordova-plugin-ionic-keyboard, but in order to ensure a smooth
+        // upgrade, we check both.
+        this._keyboard = window.Keyboard || window.cordova.plugins.Keyboard;
         resolve(this._keyboard);
       }, false);
     });

--- a/addon/services/ember-cordova/keyboard.js
+++ b/addon/services/ember-cordova/keyboard.js
@@ -13,7 +13,6 @@ const KEYBOARD_ANIMATION_TIME = 300; //ms, guestimated from SO recommendations
 
 export default Service.extend(Evented, {
   adjustBodyHeight: true,
-  shouldDisableScroll: true,
   keyboardHeight: 0,
 
   _listeners: [],
@@ -23,7 +22,7 @@ export default Service.extend(Evented, {
     this._super();
 
     this._listeners = new A();
-    this.keyboard().then(kb => { this.setup(kb); });
+    this.keyboard().then(() => { this.setup(); });
   },
 
   willDestroy() {
@@ -74,22 +73,13 @@ export default Service.extend(Evented, {
     });
   },
 
-  disableScroll(bool) {
-    this.keyboard().then((kb) => {
-      this.set('shouldDisableScroll', bool);
-      kb.disableScroll(bool);
-    });
-  },
-
-  setup(kb) {
+  setup() {
     const onKeyboardShow = this.onKeyboardShow.bind(this),
     onKeyboardHide = this.onKeyboardHide.bind(this),
     listeners = [
       { name: 'native.keyboardshow', fn: onKeyboardShow },
       { name: 'native.keyboardhide', fn: onKeyboardHide }
     ];
-
-    kb.disableScroll(this.get('shouldDisableScroll'));
 
     listeners.forEach(listener => {
       this._listeners.pushObject(listener);

--- a/addon/services/ember-cordova/keyboard.js
+++ b/addon/services/ember-cordova/keyboard.js
@@ -76,15 +76,27 @@ export default Service.extend(Evented, {
   setup() {
     const onKeyboardShow = this.onKeyboardShow.bind(this),
     onKeyboardHide = this.onKeyboardHide.bind(this),
+    onKeyboardWillHide = this.onKeyboardWillHide.bind(this),
+    onKeyboardWillShow = this.onKeyboardWillShow.bind(this),
     listeners = [
-      { name: 'native.keyboardshow', fn: onKeyboardShow },
-      { name: 'native.keyboardhide', fn: onKeyboardHide }
+      { name: 'keyboardWillShow', fn: onKeyboardWillShow },
+      { name: 'keyboardWillHide', fn: onKeyboardWillHide },
+      { name: 'keyboardDidShow', fn: onKeyboardShow },
+      { name: 'keyboardDidHide', fn: onKeyboardHide }
     ];
 
     listeners.forEach(listener => {
       this._listeners.pushObject(listener);
       window.addEventListener(listener.name, listener.fn, true);
     });
+  },
+
+  onKeyboardWillShow(e) {
+    this.trigger('keyboardWillShow', e);
+  },
+
+  onKeyboardWillHide(e) {
+    this.trigger('keyboardWillHide', e);
   },
 
   onKeyboardShow(e) {

--- a/blueprints/ember-cordova-keyboard/index.js
+++ b/blueprints/ember-cordova-keyboard/index.js
@@ -6,7 +6,7 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    ecInstaller.install('ionic-plugin-keyboard', this);
+    ecInstaller.install('cordova-plugin-ionic-keyboard', this);
   }
 };
 

--- a/testem.js
+++ b/testem.js
@@ -2,11 +2,21 @@
 module.exports = {
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
-  "launch_in_ci": [
-    "PhantomJS"
+  launch_in_ci: [
+    'Chrome'
   ],
-  "launch_in_dev": [
-    "PhantomJS",
-    "Chrome"
-  ]
+  launch_in_dev: [
+    'Chrome'
+  ],
+  browser_args: {
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=9222',
+        '--window-size=1440,900'
+      ]
+    },
+  }
 };

--- a/tests/integration/keyboard-test.js
+++ b/tests/integration/keyboard-test.js
@@ -22,11 +22,7 @@ moduleFor('service:ember-cordova/keyboard', 'Integration | Service | cordova/key
       focus: function() {}
     });
 
-    window.cordova = {
-      plugins: {
-        Keyboard: this.pluginDouble
-      }
-    };
+    window.Keyboard = this.pluginDouble;
   },
 
   afterEach: function() {


### PR DESCRIPTION
Upgrading to the new `cordova-plugin-ionic-keyboard` plugin turned out to be more involved than I expected. There are two main differences I noticed:

0. The location of the `Keyboard` plugin moved from `window.cordova.plugins.Keyboard` to `window.Keyboard`. We now check both places.
0. The event names have changed from things like `native.keyboardshow` to `keyboardDidShow`. And there are new events, i.e., DidShow and WillShow varieties.

A problem with this PR at the moment is that the event name changes are not backwards compatible and there's not a one-step upgrade path. You would need to remember to remove the old cordova plugin and add the new one. I fixed the blueprint so that for new projects it installs the correct one, but I'm not sure what the appropriate behavior is for upgrades. Is there a graceful way to handle this?